### PR TITLE
Fixing logic for date validation and adding test for it

### DIFF
--- a/src/oai_repo/repository.py
+++ b/src/oai_repo/repository.py
@@ -96,7 +96,10 @@ class OAIRepository:
                 or if date was not valid according to the repository
                 granularity.
         """
-        allowed_datefmts = ["%Y-%m-%d", "%Y-%m-%dT%H:%M:%SZ"]
+        allowed_datefmts = ["%Y-%m-%d"]
+
+        if self.data.get_identify().granularity == "YYYY-MM-DDThh:mm:ssZ":
+            allowed_datefmts.append("%Y-%m-%dT%H:%M:%SZ")
 
         if datestr is None:
             return None

--- a/src/oai_repo/repository.py
+++ b/src/oai_repo/repository.py
@@ -96,17 +96,18 @@ class OAIRepository:
                 or if date was not valid according to the repository
                 granularity.
         """
-        allowed_datefmts = ["%Y-%m-%d"]
-        if self.data.get_identify().granularity == "YYYY-MM-DDThh:mm:ssZ":
-            allowed_datefmts.append("%Y-%m-%dT%H:%M:%SZ")
+        allowed_datefmts = ["%Y-%m-%d", "%Y-%m-%dT%H:%M:%SZ"]
 
-        date = None
-        if datestr is not None:
+        if datestr is None:
+            return None
+
+        for datefmt in allowed_datefmts:
             try:
-                for datefmt in allowed_datefmts:
-                    date = datetime.strptime(datestr, datefmt).replace(tzinfo=timezone.utc)
+                date = datetime.strptime(datestr.strip(), datefmt).replace(tzinfo=timezone.utc)
+                return date
             except (TypeError, ValueError):
-                raise OAIErrorBadArgument(
+                continue
+
+        raise OAIErrorBadArgument(
                     "A date passed in not in a valid format. See Identify for granularity."
                 ) from None
-        return date

--- a/tests/data_sets.py
+++ b/tests/data_sets.py
@@ -15,6 +15,10 @@ class DataWithSets(oai_repo.DataInterface):
         { "replace": [":", "_"] }   # colons disallowed per OAI spec
     ])
 
+    def __init__(self, timestamp=False) -> None:
+        super().__init__()
+        self.timestamp = timestamp
+
     def localid(self, identifier):
         """Custom method to convert to localid"""
         return self.identifier_transform.forward(identifier)
@@ -41,7 +45,10 @@ class DataWithSets(oai_repo.DataInterface):
         ident.base_url = "https://d.lib.msu.edu/oai"
         ident.admin_email.append("oai@example.edu")
         ident.deleted_record = "no"
-        ident.granularity = "YYYY-MM-DD"
+        if self.timestamp:
+            ident.granularity = "YYYY-MM-DDThh:mm:ssZ"
+        else:
+            ident.granularity = "YYYY-MM-DD"
         ident.compression = []
         ident.earliest_datestamp = "2000-01-31"
         ident.description.append(

--- a/tests/test_datevalidation.py
+++ b/tests/test_datevalidation.py
@@ -1,0 +1,28 @@
+import pytest
+from datetime import datetime
+from .data_sets import DataWithSets
+from src.oai_repo.repository import OAIRepository
+from src.oai_repo.exceptions import OAIErrorBadArgument
+
+repo = OAIRepository(DataWithSets())
+
+@pytest.mark.parametrize(
+    ('date'),
+    [
+        '2017-01-01T00:00:00Z',
+        '2023-09-19T12:54:00Z'
+    ]
+)
+def test_valid_dates(date: str):
+    assert isinstance(repo.valid_date(date), datetime)
+
+@pytest.mark.parametrize(
+    ('date'),
+    [
+        '2017/01/01T00-00-00Z',
+        '2023.09.19T12/54/00Z'
+    ]
+)
+def test_invalid_dates(date: str):
+    with pytest.raises(OAIErrorBadArgument):
+        repo.valid_date(date)

--- a/tests/test_datevalidation.py
+++ b/tests/test_datevalidation.py
@@ -4,13 +4,13 @@ from .data_sets import DataWithSets
 from src.oai_repo.repository import OAIRepository
 from src.oai_repo.exceptions import OAIErrorBadArgument
 
-repo = OAIRepository(DataWithSets())
+repo = OAIRepository(DataWithSets(timestamp=True))
 
 @pytest.mark.parametrize(
     ('date'),
     [
         '2017-01-01T00:00:00Z',
-        '2023-09-19T12:54:00Z'
+        '2023-09-19'
     ]
 )
 def test_valid_dates(date: str):


### PR DESCRIPTION
Hello!

I had found an issue with this library when trying to use the from or until parameters for my oai-pmh service. When given date's formatted with timestamps "%Y-%m-%dT%H:%M:%SZ" the valid_date method would initially try to parse the date as "%Y-%m-%d" and would error, catch it, and not test for the other case. I forked the repository and added my changes, and also included a test as well.

The code would error out before checking the second date format, now it should be able to catch the Type and Value errors and continue to check the other date format. If it gets to the end of the for loop without returning anything, it will raise the OAIErrorBadArgument exception.

Also, when I was initially setting up my virtual environment for this repo, I was encountering problems with lxml because the version used in this repo does not work with m1 macbooks, so I updated the requirements.txt file to the latest version of lxml, but I did not include it here, I'm just mentioning it.