### PR TITLE
Fixing NameError when OAIRepoInternalException is raised

### DIFF
--- a/src/oai_repo/identify.py
+++ b/src/oai_repo/identify.py
@@ -7,6 +7,7 @@ from lxml import etree
 import validators
 from .request import OAIRequest
 from .response import OAIResponse
+from .exceptions import OAIRepoInternalException
 from .helpers import bytes_to_xml, granularity_format
 
 class IdentifyValidator:
@@ -109,7 +110,7 @@ class IdentifyResponse(OAIResponse):
         identify = self.repository.data.get_identify()
         errors = identify.errors()
         if errors:
-            raise OAIRepoInternalException("Invalid Identify instance: {errors}")
+            raise OAIRepoInternalException(f"Invalid Identify instance: {errors}")
 
         # Assemble the XML body
         xmlb = etree.Element("Identify")


### PR DESCRIPTION
Hello again!

When trying out the 0.4.0 version, there was an initial issue with trying to get to the landing page, because there would be a NameError in the console logs for our flask server. After digging through the issue, it seemed that the exception that wanted to be raised in identify.py wasn't imported into the file. 

After importing it, and updating the string returned to an f string, so that the error message would be formatted correctly, I was able to get the proper reason why my server wasn't working, which was due to an environment variable not set correctly LOL.

Anyways just making a pr so that the error message is raised correctly.