### PR TITLE
Updating parameters in validators.url

### DIFF
--- a/src/oai_repo/identify.py
+++ b/src/oai_repo/identify.py
@@ -25,7 +25,7 @@ class IdentifyValidator:
         failures = []
         if not self.repository_name or not isinstance(self.repository_name, str):
             failures.append("repository_name must be a non-empty string")
-        if not isinstance(self.base_url, str) or not validators.url(self.base_url):
+        if not isinstance(self.base_url, str) or not validators.url(self.base_url, simple_host=True):
             failures.append("base_url must be a valid URL path")
         failures.extend(self._admin_email_failures())
         failures.extend(self._deleted_record_failures())

--- a/src/oai_repo/listmetadataformats.py
+++ b/src/oai_repo/listmetadataformats.py
@@ -35,12 +35,12 @@ class MetadataFormatValidator:
     def _schema_failures(self):
         """Return a list of schema failures"""
         return ["schema must be a valid URL"] \
-            if not validators.url(self.schema) else []
+            if not validators.url(self.schema, simple_host=True) else []
 
     def _metadata_namespace_failures(self):
         """Return a list of metadata_namespace failures"""
         return ["metadata_namespace must be a valid URL"] \
-            if not validators.url(self.metadata_namespace) else []
+            if not validators.url(self.metadata_namespace, simple_host=True) else []
 
 
 class ListMetadataFormatsRequest(OAIRequest):


### PR DESCRIPTION
Another small change

With the update to the validators version in the oair_repo library, when validators.url is called on localhost urls, it will not be treated as a valid url. Adding the simple_host=true parameter to the validators.url call seems to fix this.

So a url like http://localhost:5000/oai/api?verb=Identify wouldn't work before, with our server getting an "ERROR:oaipmh.web:Internal error: Invalid Identify instance: ['base_url must be a valid URL path']", but with the simple_host parameter being added, the page loads correctly.